### PR TITLE
Refactor, Optimize, and add Stochastic Movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Field is Anionic
 Amount of Atoms in Universe: 27000
 ```
 
-![image](https://user-images.githubusercontent.com/9837366/99133467-5dfd2680-25d7-11eb-9377-de7feb36336d.png)
+![image](https://user-images.githubusercontent.com/9837366/99208853-dce09380-277e-11eb-88be-e07d2044b10c.png)
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Checking the charge..
 Field is Cationic
 Amount of Atoms in Universe: 6859000
 Amount of protons and neutrons: 1618724000
-Time to generate/mutate/pass in ms: 5793
+Time to generate/mutate/pass in ms: 4799
 test builder::it_can_shred ... ok
 
 test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/README.md
+++ b/README.md
@@ -26,14 +26,47 @@ $ ./scripts/rel.run.sh 30
 + cargo run -q --release 30
 Building Universe..
 Threads: 16
-Snapshot..
-
-Block { id: 0, x: 0, y: 0, z: 0, charge: 0, atom: Atom { electrons: 20, nucleus: Nucleus { protons: 62, neutrons: 26 } } }
-
 Universe built!
 Checking the charge..
 Field is Anionic
-Size of Universe: 27000
+Amount of Atoms in Universe: 27000
 ```
 
 ![image](https://user-images.githubusercontent.com/9837366/99133467-5dfd2680-25d7-11eb-9377-de7feb36336d.png)
+
+### Testing
+
+Bevy/ECS code is not tested. Still in beta and too many refactorings will take place over the next year or so.
+
+However if you want to fill up a bunch of RAM and see how performant the `builder::generate_universe` is, you can run the test script which runs in release mode:
+
+_warning this used up 80% of my RAM and I have 32GB of RAM!
+
+**`SHRED_SIZE=190` is cubed and then 118 default protons and neutrons are made per atom!**
+
+```
+$ SHRED_SIZE=190 ./scripts/test.sh
++ cargo test --release -- --nocapture
+   Compiling oxidizy v0.1.0 (C:\Users\boudi\Documents\Rust\oxidizy)
+    Finished release [optimized] target(s) in 1.65s
+     Running target\release\deps\oxidizy-0d20c3fcb5f5d1ba.exe
+
+running 4 tests
+Building Universe..
+Threads: 16
+Threads: 16
+Threads: 16
+test builder::it_can_sense_the_field ... ok
+test builder::it_can_begin ... ok
+test builder::it_can_infer_the_charge_of_an_atom ... ok
+Threads: 16
+Universe built!
+Checking the charge..
+Field is Cationic
+Amount of Atoms in Universe: 6859000
+Amount of protons and neutrons: 1618724000
+Time to generate/mutate/pass in ms: 5793
+test builder::it_can_shred ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Bevy/ECS code is not tested. Still in beta and too many refactorings will take p
 
 However if you want to fill up a bunch of RAM and see how performant the `builder::generate_universe` is, you can run the test script which runs in release mode:
 
-_warning this used up 80% of my RAM and I have 32GB of RAM!
+_warning this used up 80% of my RAM and I have 32GB of RAM!_
 
 **`SHRED_SIZE=190` is cubed and then 118 default protons and neutrons are made per atom!**
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 
 set -euox pipefail
 
-cargo test
+cargo test --release -- --nocapture

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -97,11 +97,22 @@ pub fn calculate_charge(block: &mut core::Block) {
 }
 
 pub fn mutate_blocks_with_new_particles(rng: &mut rand::rngs::ThreadRng, block: &mut core::Block) {
-    let (electrons, protons, neutrons): (u32, u32, u32) = (
+    let (electrons, protons, neutrons, rotation): (u32, u32, u32, u8) = (
         rng.gen_range(0, 118),
         rng.gen_range(0, 118),
         rng.gen_range(0, 118),
+        rng.gen_range(1, 6),
     );
+
+    match rotation {
+        1 => block.x += 1,
+        2 => block.x -= 1,
+        3 => block.y += 1,
+        4 => block.y -= 1,
+        5 => block.z += 1,
+        6 => block.z -= 1,
+        _ => (),
+    }
 
     block.atom.electrons = electrons;
     block.atom.nucleus.protons = core::Protons::new(protons);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,4 @@
 use rand::Rng;
-
 use rayon::prelude::*;
 
 pub mod core;
@@ -7,8 +6,12 @@ pub mod core;
 pub struct Blocks {}
 
 impl Blocks {
-    pub fn initialize_universe(parsed_size: u32, uni: &mut Vec<core::Block>) -> Vec<core::Block> {
+    pub fn initialize_universe(parsed_size: u32) -> Vec<core::Block> {
         let mut id: u32 = 0;
+        
+        let vec_size = (parsed_size * parsed_size * parsed_size) as usize;
+
+        let mut universe = Vec::with_capacity(vec_size);
     
         for x in 0..parsed_size {
             for y in 0..parsed_size {
@@ -18,7 +21,7 @@ impl Blocks {
                     let generated_protons = core::Protons::new(protons);
                     let generated_neutrons = core::Neutrons::new(neutrons);
     
-                    uni.push(core::Block {
+                    universe.push(core::Block {
                         id,
                         x,
                         y,
@@ -40,7 +43,7 @@ impl Blocks {
     
         println!("Threads: {}", rayon::current_num_threads());
     
-        uni.clone()
+        universe.clone()
     }
     
     pub fn particles(universe: &mut Vec<core::Block>, neutron: &mut [u32; 1], proton: &mut [u32; 1], electron: &mut [u32; 1]) {
@@ -80,7 +83,7 @@ impl Blocks {
         });
     
         uni_copy
-    }    
+    }
 }
 
 pub fn calculate_charge(block: &mut core::Block) {
@@ -105,11 +108,32 @@ pub fn mutate_blocks_with_new_particles(rng: &mut rand::rngs::ThreadRng, block: 
     block.atom.nucleus.neutrons = core::Neutrons::new(neutrons);
 }
 
+pub fn generate_universe(parsed_size: u32) -> Vec<core::Block> {
+    println!("Building Universe..");
+
+    let mut neturon: [u32; 1] = [0];
+    let mut proton: [u32; 1] = [0];
+    let mut electron: [u32; 1] = [0];
+
+    let mut generated_universe = Blocks::initialize_universe(parsed_size);
+
+    generated_universe = Blocks::tick(parsed_size, &mut generated_universe);
+    Blocks::particles(&mut generated_universe, &mut neturon, &mut proton, &mut electron);
+
+    println!("Universe built!\nChecking the charge..");
+
+    Blocks::charge_of_field(&mut proton, &mut electron, parsed_size as u32);
+    Blocks::atom_charge(&mut generated_universe);
+
+    println!("Amount of Atoms in Universe: {:?}", generated_universe.len());
+    println!("Amount of protons and neutrons: {}", generated_universe.len() * 118 * 2);
+
+    generated_universe
+}
+
 #[test]
-fn it_can_begin() {
-    let mut universe: Vec<core::Block> = vec![];
-    
-    Blocks::initialize_universe(5, &mut universe);
+fn it_can_begin() {    
+    let universe = Blocks::initialize_universe(5);
 
     assert_eq!(universe.len(), 125);
     
@@ -123,14 +147,41 @@ fn it_can_begin() {
 }
 
 #[test]
+fn it_can_shred() {
+    use std::time::{SystemTime};
+
+    let size = std::env::var("SHRED_SIZE");
+    let parsed_size: u32;
+
+    match size {
+        Ok(val) => parsed_size = val.trim().parse::<u32>().unwrap(),
+        Err(_e) => parsed_size = 20,
+    }
+
+    let now = SystemTime::now();
+
+    let generated_universe = generate_universe(parsed_size);
+
+    match now.elapsed() {
+        Ok(elapsed) => {
+            println!("Time to generate/mutate/pass in ms: {}", elapsed.as_millis());
+        }
+        Err(e) => {
+            println!("Error: {:?}", e);
+        }
+    }
+
+    let universe_length = generated_universe.len() as u32;
+    assert_eq!(universe_length, (parsed_size * parsed_size * parsed_size));
+}
+
+#[test]
 fn it_can_infer_the_charge_of_an_atom() {
-    let mut universe: Vec<core::Block> = vec![];
-    
     let mut neturon: [u32; 1] = [0];
     let mut proton: [u32; 1] = [0];
     let mut electron: [u32; 1] = [0];
     
-    let mut generated_universe: Vec<core::Block> = Blocks::initialize_universe(5, &mut universe);
+    let mut generated_universe: Vec<core::Block> = Blocks::initialize_universe(5);
     Blocks::tick(5, &mut generated_universe);
     Blocks::particles(&mut generated_universe, &mut neturon, &mut proton, &mut electron);
     Blocks::atom_charge(&mut generated_universe);
@@ -140,13 +191,11 @@ fn it_can_infer_the_charge_of_an_atom() {
 
 #[test]
 fn it_can_sense_the_field() {
-    let mut universe: Vec<core::Block> = vec![];
-
     let mut neturon: [u32; 1] = [0];
     let mut proton: [u32; 1] = [0];
     let mut electron: [u32; 1] = [0];
 
-    universe = Blocks::initialize_universe(2, &mut universe);
+    let mut universe = Blocks::initialize_universe(2);
     Blocks::particles(&mut universe, &mut neturon, &mut proton, &mut electron);
 
     assert_eq!(universe.len(), 8);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -43,7 +43,7 @@ impl Blocks {
     
         println!("Threads: {}", rayon::current_num_threads());
     
-        universe.clone()
+        universe
     }
     
     pub fn particles(universe: &mut Vec<core::Block>, neutron: &mut [u32; 1], proton: &mut [u32; 1], electron: &mut [u32; 1]) {

--- a/src/builder/core.rs
+++ b/src/builder/core.rs
@@ -140,8 +140,6 @@ impl ElectricCharge {
     }
 }
 
-
-
 #[derive(Debug, Copy, Clone)]
 pub struct Baryons {}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
         .add_system(update_block_atoms.system())
         .add_system(update_block_spheres.system())
         .add_system(camera_movement.system())
+        .add_system(random_movement.system())
         .add_resource(ClearColor(Color::rgb(0.04, 0.04, 0.04)))
         .run();
 }
@@ -132,6 +133,16 @@ fn camera_movement(
  
             transform.translation += input_dir * time.delta_seconds * 10.0;
         }
+    }
+}
+
+fn random_movement(
+    mut query: Query<(&mut Transform, &mut builder::core::Block)>,
+) {
+    for (mut transform,  block) in query.iter_mut() {
+        let new_translation = Vec3::new(block.x as f32, block.y as f32, block.z as f32);
+
+        transform.translation = new_translation;
     }
 }
 


### PR DESCRIPTION
Get system iterations for regen down from 20ms to 7ms.

Refactor generate_universe

Include ability to perf test without nightly in release mode

Add random movement

### Example

After waiting about 30 seconds this is a snapshot of stochatic movement:

`$ ./scripts/rel.run.sh 60` (90% RAM on 32GB)

```
Amount of Atoms in Universe: 216000
Amount of protons and neutrons: 50976000
```

![image](https://user-images.githubusercontent.com/9837366/99208853-dce09380-277e-11eb-88be-e07d2044b10c.png)
