### PR TITLE
optimize tick

### DIFF
--- a/crates/unigen/src/builder.rs
+++ b/crates/unigen/src/builder.rs
@@ -76,18 +76,14 @@ impl Blocks {
         }
     }
     
-    pub fn tick(universe: &mut Vec<core::Block>) -> Vec<core::Block> {
-        let mut uni_copy: Vec<core::Block> = universe.clone();
-        
+    pub fn tick(universe: &mut Vec<core::Block>) {
         let threads = rayon::current_num_threads();
 
-        uni_copy.par_chunks_mut(threads).for_each_init(|| rand::thread_rng(), |rng, blocks| {
+        universe.par_chunks_mut(threads).for_each_init(|| rand::thread_rng(), |rng, blocks| {
             for block in blocks {
                 mutate_blocks_with_new_particles(rng, block);
             }
         });
-    
-        uni_copy
     }
 }
 
@@ -133,7 +129,7 @@ pub fn generate_universe(parsed_size: u32) -> Vec<core::Block> {
 
     let mut generated_universe = Blocks::initialize_universe(parsed_size);
 
-    generated_universe = Blocks::tick(&mut generated_universe);
+    Blocks::tick(&mut generated_universe);
     Blocks::particles(&mut generated_universe, &mut neturon, &mut proton, &mut electron);
 
     println!("{}", "--------------------------------".purple().bold());


### PR DESCRIPTION
Went from 4.6 seconds (after rayon optimization) to 3.5 seconds.

That's a 24% speed boost.

Also cut memory profile in half!

So in 2 PRs we went from 4.8 seconds to 3.5.

Total perf boost of 27% with 2 small changes.

First PR of this optimization sweep: https://github.com/selfup/oxidizy/pull/16

Insane!

```
Atoms: 8000000
Baryons: 1888000000
Quarks: 5664000000
--------------------------------

real    0m3.552s
```