### PR TITLE
fix diagonal drift (down and right)

### DIFF
--- a/crates/unigen/src/builder.rs
+++ b/crates/unigen/src/builder.rs
@@ -132,7 +132,7 @@ pub fn mutate_blocks_with_new_particles<R: Rng>(rng: &mut R, block: &mut core::B
         rng.gen_range(0..118),
         rng.gen_range(0..118),
         rng.gen_range(0..118),
-        rng.gen_range(1..6),
+        rng.gen_range(1..7),
     );
 
     match rotation {


### PR DESCRIPTION
No more having to constantly use the camera to follow the "influence" of brownian motion. Turns out the range was wrong in the `.gen_range` call this whole time 😅 