### PR TITLE
Update internal versions and bump rust edition to 2024

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Rustup Update
+    - run: rustup update
     - name: OS Deps
       run: "sudo apt-get update \
               && sudo apt-get install \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Rustup Update
-    - run: rustup update
+      run: rustup update
     - name: OS Deps
       run: "sudo apt-get update \
               && sudo apt-get install \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3079,7 +3079,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oxidizy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bevy",
  "unigen",
@@ -4019,7 +4019,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unigen"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "colored",
  "rand 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "oxidizy"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["selfup <boudinot.regis@yahoo.com>"]
-edition = "2021"
+edition = "2024"
 
 [workspace]
 members = ["crates/*"]
 
 [dependencies]
-unigen = { path = "crates/unigen", version = "0.2.0", default-features = false }
+unigen = { path = "crates/unigen", version = "0.3.0", default-features = false }
 
 bevy = "0.15.2"

--- a/crates/unigen/Cargo.toml
+++ b/crates/unigen/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "unigen"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["selfup <boudinot.regis@yahoo.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rand = "0.9.0"


### PR DESCRIPTION
Bump both `oxidizy` and `unigen` to `0.3.0`

Bump rust `edition` to `2024` in both `Cargo.toml` files

#### Oxidizy

```toml
[package]
name = "oxidizy"
version = "0.3.0"
edition = "2024"

[workspace]
members = ["crates/*"]

[dependencies]
unigen = { path = "crates/unigen", version = "0.3.0", default-features = false }
```

#### Unigen

```toml
[package]
name = "unigen"
version = "0.3.0"
edition = "2024"
```