### PR TITLE
Custom GPU Instancing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2268,7 +2268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3920,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -4147,7 +4147,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4750,11 +4750,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unigen"
-version = "0.4.2"
-source = "git+https://github.com/selfup/unigen-rs#3f92aa3715a235fb8989d21f9a2768a9d162cdbc"
+version = "0.4.3"
+source = "git+https://github.com/selfup/unigen-rs#42e91aeb1996f0c14c89780d30de0fc1799c5fad"
 dependencies = [
  "colored",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
 ]
 
@@ -5220,7 +5220,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,9 +1678,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -3661,6 +3661,8 @@ name = "oxidizy"
 version = "0.4.1"
 dependencies = [
  "bevy",
+ "bytemuck",
+ "rayon",
  "unigen",
 ]
 
@@ -3982,9 +3984,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "oxidizy"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bevy",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxidizy"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["selfup <boudinot.regis@yahoo.com>"]
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2024"
 unigen = { git = "https://github.com/selfup/unigen-rs", version = "0.4.2", default-features = false }
 
 bevy = "0.18.1"
+bytemuck = { version = "1.25.0", features = ["derive"] }
+rayon = "1.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["selfup <boudinot.regis@yahoo.com>"]
 edition = "2024"
 
 [dependencies]
-unigen = { git = "https://github.com/selfup/unigen-rs", version = "0.4.2", default-features = false }
+unigen = { git = "https://github.com/selfup/unigen-rs", version = "0.4.3", default-features = false }
 
 bevy = "0.18.1"
 bytemuck = { version = "1.25.0", features = ["derive"] }

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -1,0 +1,40 @@
+#import bevy_pbr::mesh_functions::{get_world_from_local, mesh_position_local_to_clip}
+
+struct Vertex {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) uv: vec2<f32>,
+
+    @location(3) i_pos_scale: vec4<f32>,
+    @location(4) i_color: vec4<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) normal: vec3<f32>,
+};
+
+@vertex
+fn vertex(vertex: Vertex) -> VertexOutput {
+    let position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
+    var out: VertexOutput;
+    out.clip_position = mesh_position_local_to_clip(
+        get_world_from_local(0u),
+        vec4<f32>(position, 1.0)
+    );
+    out.color = vertex.i_color;
+    // Spheres have no per-instance rotation and only uniform scale + translation,
+    // so the mesh-local normal is equivalent to the world normal here.
+    out.normal = vertex.normal;
+    return out;
+}
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let light_dir = normalize(vec3<f32>(0.4, 0.8, 0.45));
+    let ambient = 0.35;
+    let diffuse = max(dot(normalize(in.normal), light_dir), 0.0);
+    let shade = ambient + (1.0 - ambient) * diffuse;
+    return vec4<f32>(in.color.rgb * shade, in.color.a);
+}

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -4,7 +4,6 @@ struct Vertex {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,
     @location(2) uv: vec2<f32>,
-
     @location(3) i_pos_scale: vec4<f32>,
     @location(4) i_color: vec4<f32>,
 };
@@ -18,23 +17,32 @@ struct VertexOutput {
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
     let position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
+
     var out: VertexOutput;
+
     out.clip_position = mesh_position_local_to_clip(
         get_world_from_local(0u),
         vec4<f32>(position, 1.0)
     );
+
     out.color = vertex.i_color;
+
     // Spheres have no per-instance rotation and only uniform scale + translation,
     // so the mesh-local normal is equivalent to the world normal here.
     out.normal = vertex.normal;
+
     return out;
 }
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    let light_dir = normalize(vec3<f32>(0.4, 0.8, 0.45));
     let ambient = 0.35;
+    
+    let light_dir = normalize(vec3<f32>(0.4, 0.8, 0.45));
+
     let diffuse = max(dot(normalize(in.normal), light_dir), 0.0);
+    
     let shade = ambient + (1.0 - ambient) * diffuse;
+
     return vec4<f32>(in.color.rgb * shade, in.color.a);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use bevy::camera::visibility::NoFrustumCulling;
 use bevy::core_pipeline::core_3d::Transparent3d;
 use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::ecs::query::QueryItem;
-use bevy::ecs::system::{lifetimeless::*, SystemParamItem};
+use bevy::ecs::system::{SystemParamItem, lifetimeless::*};
 use bevy::mesh::{MeshVertexBufferLayoutRef, VertexBufferLayout};
 use bevy::pbr::{
     MeshPipeline, MeshPipelineKey, RenderMeshInstances, SetMeshBindGroup, SetMeshViewBindGroup,
@@ -10,7 +10,7 @@ use bevy::pbr::{
 };
 use bevy::prelude::*;
 use bevy::render::extract_component::{ExtractComponent, ExtractComponentPlugin};
-use bevy::render::mesh::{allocator::MeshAllocator, RenderMesh, RenderMeshBufferInfo};
+use bevy::render::mesh::{RenderMesh, RenderMeshBufferInfo, allocator::MeshAllocator};
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{
     AddRenderCommand, DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand,
@@ -103,8 +103,11 @@ fn update_atoms(mut query: Query<(&mut Blocks, &mut InstanceMaterialData)>) {
             .zip(data_slice.par_iter_mut())
             .for_each(|(block, inst)| {
                 builder::mutate_blocks_with_new_particles(&mut unigen::rand::rng(), block);
+
                 builder::calculate_charge(block);
+
                 inst.position = Vec3::new(block.x as f32, block.y as f32, block.z as f32);
+
                 inst.color = charge_to_color(block.charge);
             });
     }
@@ -125,6 +128,7 @@ fn camera_movement(
     } else if input_dir.length() > 0. {
         for mut transform in query.iter_mut() {
             let input_dir = (transform.rotation * input_dir).normalize();
+
             transform.translation += input_dir * (time.delta_secs_f64() * 50.0) as f32;
         }
     }
@@ -140,18 +144,23 @@ fn get_input_dir(
     if keyboard_input.pressed(KeyCode::KeyW) {
         input_dir -= Vec3::new(0.0, 0.0, 1.0);
     }
+
     if keyboard_input.pressed(KeyCode::KeyS) {
         input_dir += Vec3::new(0.0, 0.0, 1.0);
     }
+
     if keyboard_input.pressed(KeyCode::KeyA) {
         input_dir -= Vec3::new(1.0, 0.0, 0.0);
     }
+
     if keyboard_input.pressed(KeyCode::KeyD) {
         input_dir += Vec3::new(1.0, 0.0, 0.0);
     }
+
     if keyboard_input.pressed(KeyCode::Space) {
         input_dir += Vec3::new(0.0, 1.0, 0.0);
     }
+
     if keyboard_input.pressed(KeyCode::ShiftLeft) {
         input_dir -= Vec3::new(0.0, 1.0, 0.0);
     }
@@ -165,12 +174,16 @@ fn get_input_dir(
                         "block_id_zero x: {} - y: {} - z: {}",
                         block.x, block.y, block.z
                     );
+
                     known_location = Vec3::new(block.x as f32, block.y as f32, block.z as f32);
+
                     snap_to_universe = true;
+
                     break 'outer;
                 }
             }
         }
+
         input_dir = known_location;
     }
 
@@ -236,8 +249,7 @@ fn queue_custom(
     let draw_custom = transparent_3d_draw_functions.read().id::<DrawCustom>();
 
     for (view, msaa) in &views {
-        let Some(transparent_phase) =
-            transparent_render_phases.get_mut(&view.retained_view_entity)
+        let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
         else {
             continue;
         };
@@ -247,19 +259,22 @@ fn queue_custom(
         let rangefinder = view.rangefinder3d();
 
         for (entity, main_entity) in &material_meshes {
-            let Some(mesh_instance) =
-                render_mesh_instances.render_mesh_queue_data(*main_entity)
+            let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*main_entity)
             else {
                 continue;
             };
+
             let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
                 continue;
             };
+
             let key =
                 view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology());
+
             let pipeline = pipelines
                 .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
                 .unwrap();
+
             transparent_phase.add(Transparent3d {
                 entity: (entity, *main_entity),
                 pipeline,
@@ -290,6 +305,7 @@ fn prepare_instance_buffers(
             contents: bytemuck::cast_slice(instance_data.as_slice()),
             usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
         });
+
         commands.entity(entity).insert(InstanceBuffer {
             buffer,
             length: instance_data.len(),
@@ -325,6 +341,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
         let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
 
         descriptor.vertex.shader = self.shader.clone();
+
         descriptor.vertex.buffers.push(VertexBufferLayout {
             array_stride: size_of::<InstanceData>() as u64,
             step_mode: VertexStepMode::Instance,
@@ -341,6 +358,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
                 },
             ],
         });
+
         descriptor.fragment.as_mut().unwrap().shader = self.shader.clone();
 
         // Atoms are opaque even though we're in the Transparent3d phase;
@@ -384,17 +402,19 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
     ) -> RenderCommandResult {
         let mesh_allocator = mesh_allocator.into_inner();
 
-        let Some(mesh_instance) =
-            render_mesh_instances.render_mesh_queue_data(item.main_entity())
+        let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(item.main_entity())
         else {
             return RenderCommandResult::Skip;
         };
+
         let Some(gpu_mesh) = meshes.into_inner().get(mesh_instance.mesh_asset_id) else {
             return RenderCommandResult::Skip;
         };
+
         let Some(instance_buffer) = instance_buffer else {
             return RenderCommandResult::Skip;
         };
+
         let Some(vertex_buffer_slice) =
             mesh_allocator.mesh_vertex_slice(&mesh_instance.mesh_asset_id)
         else {
@@ -414,7 +434,9 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
                 else {
                     return RenderCommandResult::Skip;
                 };
+
                 pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
+
                 pass.draw_indexed(
                     index_buffer_slice.range.start..(index_buffer_slice.range.start + count),
                     vertex_buffer_slice.range.start as i32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,262 +1,430 @@
+use bevy::camera::visibility::NoFrustumCulling;
+use bevy::core_pipeline::core_3d::Transparent3d;
 use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
+use bevy::ecs::query::QueryItem;
+use bevy::ecs::system::{lifetimeless::*, SystemParamItem};
+use bevy::mesh::{MeshVertexBufferLayoutRef, VertexBufferLayout};
+use bevy::pbr::{
+    MeshPipeline, MeshPipelineKey, RenderMeshInstances, SetMeshBindGroup, SetMeshViewBindGroup,
+    SetMeshViewBindingArrayBindGroup,
+};
 use bevy::prelude::*;
+use bevy::render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy::render::mesh::{allocator::MeshAllocator, RenderMesh, RenderMeshBufferInfo};
+use bevy::render::render_asset::RenderAssets;
+use bevy::render::render_phase::{
+    AddRenderCommand, DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand,
+    RenderCommandResult, SetItemPipeline, TrackedRenderPass, ViewSortedRenderPhases,
+};
+use bevy::render::render_resource::*;
+use bevy::render::renderer::RenderDevice;
+use bevy::render::sync_world::MainEntity;
+use bevy::render::view::{ExtractedView, NoIndirectDrawing};
+use bevy::render::{Render, RenderApp, RenderStartup, RenderSystems};
+use bytemuck::{Pod, Zeroable};
+use rayon::prelude::*;
 use std::env;
-
-const DEFAULT_SIZE: u32 = 30;
-
 use unigen::builder;
 
-type Material = StandardMaterial;
-
-#[allow(unused_imports)]
-#[derive(Resource)]
-struct ChargedAtomMaterials {
-    materials: Vec<Handle<Material>>,
-}
-
-impl ChargedAtomMaterials {
-    fn new(mut asset_server: ResMut<Assets<StandardMaterial>>) -> Self {
-        let lower_bound: i8 = 0;
-        let upper_bound: i8 = 3;
-
-        Self {
-            materials: {
-                (lower_bound..upper_bound)
-                    .map(|r| {
-                        let color: Color = Color::srgb(r as f32, 0., 1.);
-
-                        asset_server.add(color)
-                    })
-                    .into_iter()
-                    .collect()
-            },
-        }
-    }
-
-    fn get(&self, r: i8) -> &Handle<Material> {
-        let lower_bound: i8 = -1;
-        let lower_bound_index_map: usize = 2;
-
-        if r == lower_bound {
-            &self.materials[lower_bound_index_map]
-        } else {
-            &self.materials[r as usize]
-        }
-    }
-}
+const DEFAULT_SIZE: u32 = 30;
+const SHADER_ASSET_PATH: &str = "shaders/instancing.wgsl";
 
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(ImagePlugin::default_nearest()),
+            DefaultPlugins,
             LogDiagnosticsPlugin::default(),
             FrameTimeDiagnosticsPlugin::default(),
+            CustomMaterialPlugin,
         ))
-        .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                update_block_atoms,
-                update_block_spheres,
-                update_sphere_positions,
-                camera_movement,
-            ),
-        )
         .insert_resource(ClearColor(Color::srgb(0.04, 0.04, 0.04)))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (update_atoms, camera_movement))
         .run();
 }
 
 #[derive(Component)]
-struct CameraMatcher();
+struct CameraMatcher;
 
 #[derive(Component)]
-struct BlockMatcher {
-    block: builder::core::Block,
+struct Blocks(Vec<builder::core::Block>);
+
+fn charge_to_color(charge: i8) -> [f32; 4] {
+    match charge {
+        -1 => [1.0, 0.3, 0.3, 1.0],
+        0 => [0.2, 0.4, 1.0, 1.0],
+        1 => [1.0, 0.3, 1.0, 1.0],
+        2 => [1.0, 1.0, 0.3, 1.0],
+        _ => [1.0, 1.0, 1.0, 1.0],
+    }
 }
 
-fn setup(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    asset_server: ResMut<Assets<Material>>,
-) {
-    commands.spawn(DirectionalLight {
-        illuminance: light_consts::lux::OVERCAST_DAY,
-        shadows_enabled: false,
-        ..default()
-    });
-
-    commands.spawn(Transform {
-        translation: Vec3::new(0.0, 2.0, 0.0),
-        rotation: Quat::from_rotation_x(-3.14 / 4.),
-        ..default()
-    });
-
+fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     let parsed_size: u32 = if let Some(arg) = env::args().nth(1) {
         arg.trim().parse().unwrap()
     } else {
         DEFAULT_SIZE
     };
 
-    let charged_atom_materials = ChargedAtomMaterials::new(asset_server);
-
     let blocks = builder::generate_universe(parsed_size);
 
-    let mesh_handle = meshes.add(Sphere::new(0.15).mesh().ico(5).unwrap());
+    let instance_data: Vec<InstanceData> = blocks
+        .iter()
+        .map(|b| InstanceData {
+            position: Vec3::new(b.x as f32, b.y as f32, b.z as f32),
+            scale: 1.0,
+            color: charge_to_color(b.charge),
+        })
+        .collect();
 
-    for block in blocks {
-        let x = block.x as f32;
-        let y = block.y as f32;
-        let z = block.z as f32;
-
-        let r = block.charge;
-
-        commands
-            .spawn((
-                Mesh3d(mesh_handle.clone()),
-                MeshMaterial3d(charged_atom_materials.get(r).clone()),
-                Transform::from_xyz(x, y, z),
-            ))
-            .insert(BlockMatcher { block });
-    }
-
-    commands.insert_resource(charged_atom_materials);
-
-    commands.insert_resource(GlobalAmbientLight {
-        color: Color::WHITE,
-        brightness: 0.35,
-        affects_lightmapped_meshes: false,
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Sphere::new(0.15).mesh().ico(1).unwrap())),
+        InstanceMaterialData(instance_data),
+        Blocks(blocks),
+        NoFrustumCulling,
+    ));
 
     let up = Vec3::new(0.0, 1.0, 0.0);
 
-    commands
-        .spawn((
-            Camera3d::default(),
-            Transform::from_translation(Vec3::new(200.0, 150.0, 250.0))
-                .looking_at(Vec3::default(), up),
-        ))
-        .insert(CameraMatcher());
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(200.0, 150.0, 250.0)).looking_at(Vec3::default(), up),
+        NoIndirectDrawing,
+        CameraMatcher,
+    ));
 }
 
-fn update_block_atoms(mut query: Query<&mut BlockMatcher>) {
-    query.par_iter_mut().for_each(|mut block| {
-        builder::mutate_blocks_with_new_particles(&mut unigen::rand::rng(), &mut block.block);
-
-        builder::calculate_charge(&mut block.block);
-    });
-}
-
-fn update_block_spheres(
-    charged_atom_materials: Res<ChargedAtomMaterials>,
-    mut query: Query<(&mut MeshMaterial3d<StandardMaterial>, &mut BlockMatcher)>,
-) {
-    query
-        .par_iter_mut()
-        .for_each(|(mut material_handle, block_matcher)| {
-            let r = block_matcher.block.charge;
-
-            let _id = material_handle.id();
-
-            *material_handle = MeshMaterial3d(charged_atom_materials.get(r).clone());
-        });
-}
-
-fn update_sphere_positions(mut query: Query<(&mut Transform, &BlockMatcher)>) {
-    query
-        .par_iter_mut()
-        .for_each(|(mut transform, block_matcher)| {
-            let block = block_matcher.block;
-
-            let new_translation = Vec3::new(block.x as f32, block.y as f32, block.z as f32);
-
-            transform.translation = new_translation;
-        });
+fn update_atoms(mut query: Query<(&mut Blocks, &mut InstanceMaterialData)>) {
+    for (mut blocks, mut data) in &mut query {
+        let blocks_slice = blocks.0.as_mut_slice();
+        let data_slice = data.0.as_mut_slice();
+        blocks_slice
+            .par_iter_mut()
+            .zip(data_slice.par_iter_mut())
+            .for_each(|(block, inst)| {
+                builder::mutate_blocks_with_new_particles(&mut unigen::rand::rng(), block);
+                builder::calculate_charge(block);
+                inst.position = Vec3::new(block.x as f32, block.y as f32, block.z as f32);
+                inst.color = charge_to_color(block.charge);
+            });
+    }
 }
 
 fn camera_movement(
     time: Res<Time>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut query: Query<(&mut Transform, &mut CameraMatcher)>,
-    block_query: Query<&BlockMatcher>,
+    mut query: Query<&mut Transform, With<CameraMatcher>>,
+    blocks_query: Query<&Blocks>,
 ) {
-    let results = get_input_dir(keyboard_input, block_query);
-    let input_dir = results.0;
-    let snap_to_grid = results.1;
+    let (input_dir, snap_to_grid) = get_input_dir(keyboard_input, blocks_query);
 
     if snap_to_grid {
-        for (mut transform, _camera) in query.iter_mut() {
+        for mut transform in query.iter_mut() {
             transform.translation = input_dir;
         }
-    } else {
-        if input_dir.length() > 0. {
-            for (mut transform, _camera) in query.iter_mut() {
-                let input_dir = (transform.rotation * input_dir).normalize();
-
-                transform.translation += input_dir * (time.delta_secs_f64() * 50.0) as f32;
-            }
+    } else if input_dir.length() > 0. {
+        for mut transform in query.iter_mut() {
+            let input_dir = (transform.rotation * input_dir).normalize();
+            transform.translation += input_dir * (time.delta_secs_f64() * 50.0) as f32;
         }
     }
 }
 
 fn get_input_dir(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    query: Query<&BlockMatcher>,
+    blocks_query: Query<&Blocks>,
 ) -> (Vec3, bool) {
     let mut input_dir = Vec3::default();
     let mut snap_to_universe = false;
 
     if keyboard_input.pressed(KeyCode::KeyW) {
-        let forward = Vec3::new(0.0, 0.0, 1.0);
-        input_dir -= forward;
+        input_dir -= Vec3::new(0.0, 0.0, 1.0);
     }
-
     if keyboard_input.pressed(KeyCode::KeyS) {
-        let forward = Vec3::new(0.0, 0.0, 1.0);
-        input_dir += forward;
+        input_dir += Vec3::new(0.0, 0.0, 1.0);
     }
-
     if keyboard_input.pressed(KeyCode::KeyA) {
-        let right = Vec3::new(1.0, 0.0, 0.0);
-        input_dir -= right;
+        input_dir -= Vec3::new(1.0, 0.0, 0.0);
     }
-
     if keyboard_input.pressed(KeyCode::KeyD) {
-        let right = Vec3::new(1.0, 0.0, 0.0);
-        input_dir += right;
+        input_dir += Vec3::new(1.0, 0.0, 0.0);
     }
-
     if keyboard_input.pressed(KeyCode::Space) {
-        let up = Vec3::new(0.0, 1.0, 0.0);
-        input_dir += up;
+        input_dir += Vec3::new(0.0, 1.0, 0.0);
     }
-
     if keyboard_input.pressed(KeyCode::ShiftLeft) {
-        let up = Vec3::new(0.0, 1.0, 0.0);
-        input_dir -= up;
+        input_dir -= Vec3::new(0.0, 1.0, 0.0);
     }
 
     if keyboard_input.pressed(KeyCode::KeyF) {
         let mut known_location = Vec3::default();
-
-        for block in &query {
-            if block.block.id == 0 {
-                info!(
-                    "block_id_zero x: {} - y: {} - z: {}",
-                    block.block.x, block.block.y, block.block.z
-                );
-
-                known_location.x = block.block.x as f32;
-                known_location.y = block.block.y as f32;
-                known_location.z = block.block.z as f32;
-
-                snap_to_universe = true;
-
-                break;
+        'outer: for blocks in &blocks_query {
+            for block in &blocks.0 {
+                if block.id == 0 {
+                    info!(
+                        "block_id_zero x: {} - y: {} - z: {}",
+                        block.x, block.y, block.z
+                    );
+                    known_location = Vec3::new(block.x as f32, block.y as f32, block.z as f32);
+                    snap_to_universe = true;
+                    break 'outer;
+                }
             }
         }
-
         input_dir = known_location;
     }
 
     (input_dir, snap_to_universe)
+}
+
+// ---------------------------------------------------------------------------
+// Custom GPU instancing pipeline
+// Adapted from Bevy 0.18.1 examples/shader_advanced/custom_shader_instancing.rs
+// ---------------------------------------------------------------------------
+
+#[derive(Component, Deref)]
+struct InstanceMaterialData(Vec<InstanceData>);
+
+impl ExtractComponent for InstanceMaterialData {
+    type QueryData = &'static InstanceMaterialData;
+    type QueryFilter = ();
+    type Out = Self;
+
+    fn extract_component(item: QueryItem<'_, '_, Self::QueryData>) -> Option<Self> {
+        Some(InstanceMaterialData(item.0.clone()))
+    }
+}
+
+struct CustomMaterialPlugin;
+
+impl Plugin for CustomMaterialPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(ExtractComponentPlugin::<InstanceMaterialData>::default());
+        app.sub_app_mut(RenderApp)
+            .add_render_command::<Transparent3d, DrawCustom>()
+            .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
+            .add_systems(RenderStartup, init_custom_pipeline)
+            .add_systems(
+                Render,
+                (
+                    queue_custom.in_set(RenderSystems::QueueMeshes),
+                    prepare_instance_buffers.in_set(RenderSystems::PrepareResources),
+                ),
+            );
+    }
+}
+
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct InstanceData {
+    position: Vec3,
+    scale: f32,
+    color: [f32; 4],
+}
+
+fn queue_custom(
+    transparent_3d_draw_functions: Res<DrawFunctions<Transparent3d>>,
+    custom_pipeline: Res<CustomPipeline>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<CustomPipeline>>,
+    pipeline_cache: Res<PipelineCache>,
+    meshes: Res<RenderAssets<RenderMesh>>,
+    render_mesh_instances: Res<RenderMeshInstances>,
+    material_meshes: Query<(Entity, &MainEntity), With<InstanceMaterialData>>,
+    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
+    views: Query<(&ExtractedView, &Msaa)>,
+) {
+    let draw_custom = transparent_3d_draw_functions.read().id::<DrawCustom>();
+
+    for (view, msaa) in &views {
+        let Some(transparent_phase) =
+            transparent_render_phases.get_mut(&view.retained_view_entity)
+        else {
+            continue;
+        };
+
+        let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
+        let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
+        let rangefinder = view.rangefinder3d();
+
+        for (entity, main_entity) in &material_meshes {
+            let Some(mesh_instance) =
+                render_mesh_instances.render_mesh_queue_data(*main_entity)
+            else {
+                continue;
+            };
+            let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
+                continue;
+            };
+            let key =
+                view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology());
+            let pipeline = pipelines
+                .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
+                .unwrap();
+            transparent_phase.add(Transparent3d {
+                entity: (entity, *main_entity),
+                pipeline,
+                draw_function: draw_custom,
+                distance: rangefinder.distance(&mesh_instance.center),
+                batch_range: 0..1,
+                extra_index: PhaseItemExtraIndex::None,
+                indexed: true,
+            });
+        }
+    }
+}
+
+#[derive(Component)]
+struct InstanceBuffer {
+    buffer: Buffer,
+    length: usize,
+}
+
+fn prepare_instance_buffers(
+    mut commands: Commands,
+    query: Query<(Entity, &InstanceMaterialData)>,
+    render_device: Res<RenderDevice>,
+) {
+    for (entity, instance_data) in &query {
+        let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: Some("instance data buffer"),
+            contents: bytemuck::cast_slice(instance_data.as_slice()),
+            usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
+        });
+        commands.entity(entity).insert(InstanceBuffer {
+            buffer,
+            length: instance_data.len(),
+        });
+    }
+}
+
+#[derive(Resource)]
+struct CustomPipeline {
+    shader: Handle<Shader>,
+    mesh_pipeline: MeshPipeline,
+}
+
+fn init_custom_pipeline(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mesh_pipeline: Res<MeshPipeline>,
+) {
+    commands.insert_resource(CustomPipeline {
+        shader: asset_server.load(SHADER_ASSET_PATH),
+        mesh_pipeline: mesh_pipeline.clone(),
+    });
+}
+
+impl SpecializedMeshPipeline for CustomPipeline {
+    type Key = MeshPipelineKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayoutRef,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
+
+        descriptor.vertex.shader = self.shader.clone();
+        descriptor.vertex.buffers.push(VertexBufferLayout {
+            array_stride: size_of::<InstanceData>() as u64,
+            step_mode: VertexStepMode::Instance,
+            attributes: vec![
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 0,
+                    shader_location: 3,
+                },
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: VertexFormat::Float32x4.size(),
+                    shader_location: 4,
+                },
+            ],
+        });
+        descriptor.fragment.as_mut().unwrap().shader = self.shader.clone();
+
+        // Atoms are opaque even though we're in the Transparent3d phase;
+        // force depth write + depth test so a closer atom drawn later still
+        // wins the pixel and stacked motion stays visible.
+        if let Some(depth_stencil) = descriptor.depth_stencil.as_mut() {
+            depth_stencil.depth_write_enabled = true;
+            depth_stencil.depth_compare = CompareFunction::GreaterEqual;
+        }
+
+        Ok(descriptor)
+    }
+}
+
+type DrawCustom = (
+    SetItemPipeline,
+    SetMeshViewBindGroup<0>,
+    SetMeshViewBindingArrayBindGroup<1>,
+    SetMeshBindGroup<2>,
+    DrawMeshInstanced,
+);
+
+struct DrawMeshInstanced;
+
+impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
+    type Param = (
+        SRes<RenderAssets<RenderMesh>>,
+        SRes<RenderMeshInstances>,
+        SRes<MeshAllocator>,
+    );
+    type ViewQuery = ();
+    type ItemQuery = Read<InstanceBuffer>;
+
+    #[inline]
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        instance_buffer: Option<&'w InstanceBuffer>,
+        (meshes, render_mesh_instances, mesh_allocator): SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let mesh_allocator = mesh_allocator.into_inner();
+
+        let Some(mesh_instance) =
+            render_mesh_instances.render_mesh_queue_data(item.main_entity())
+        else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(gpu_mesh) = meshes.into_inner().get(mesh_instance.mesh_asset_id) else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(instance_buffer) = instance_buffer else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(vertex_buffer_slice) =
+            mesh_allocator.mesh_vertex_slice(&mesh_instance.mesh_asset_id)
+        else {
+            return RenderCommandResult::Skip;
+        };
+
+        pass.set_vertex_buffer(0, vertex_buffer_slice.buffer.slice(..));
+        pass.set_vertex_buffer(1, instance_buffer.buffer.slice(..));
+
+        match &gpu_mesh.buffer_info {
+            RenderMeshBufferInfo::Indexed {
+                index_format,
+                count,
+            } => {
+                let Some(index_buffer_slice) =
+                    mesh_allocator.mesh_index_slice(&mesh_instance.mesh_asset_id)
+                else {
+                    return RenderCommandResult::Skip;
+                };
+                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
+                pass.draw_indexed(
+                    index_buffer_slice.range.start..(index_buffer_slice.range.start + count),
+                    vertex_buffer_slice.range.start as i32,
+                    0..instance_buffer.length as u32,
+                );
+            }
+            RenderMeshBufferInfo::NonIndexed => {
+                pass.draw(vertex_buffer_slice.range, 0..instance_buffer.length as u32);
+            }
+        }
+        RenderCommandResult::Success
+    }
 }


### PR DESCRIPTION
# What Changed

`./scripts/rel.run 120` at 1.728M atoms now runs at 20fps instead of 1.2FPS!!

### Custom GPU instancing for atoms

* one draw call, ~17x FPS at 1.728M

* Replace per-atom ECS entities with a single entity carrying a Vec<Block>
and an InstanceMaterialData(Vec<InstanceData>). Sim runs over the Vec
via rayon, and a custom render pipeline (adapted from Bevy 0.18.1's
custom_shader_instancing example) draws all atoms in a single
instanced draw call.

* Bevy's per-frame Changed<Transform> / Changed<MeshMaterial3d> cascade
across 1.728M entities was costing ~770ms/frame on M3 Ultra (1.2 FPS).
With instancing the same scene runs at ~20 FPS, and 8M atoms run at
~3.5 FPS.

### Also:

* Force depth_write + GreaterEqual depth_compare on the Transparent3d
  pipeline so stacked atoms render with correct occlusion.
* Distinct charge -> color mapping (red/blue/magenta/yellow) plus
  cheap Lambertian shading in the fragment shader.